### PR TITLE
bug out un-gracefully on Windows

### DIFF
--- a/tasks/potomo.js
+++ b/tasks/potomo.js
@@ -18,11 +18,13 @@ module.exports = function( grunt ) {
 		});
 
 		// Return warning if not found msgfmt command
-		if ( ! shell.which( 'msgfmt' ) ) {
-			return grunt.fail.warn(
-				'\nYou need to have "GNU Gettext" installed and in your PATH for this task to work.' +
-				'More info: http://www.gnu.org/software/gettext\n'
-			);
+		if ( process.platform !== 'win32' ) {
+			if ( ! shell.which( 'msgfmt' ) ) {
+				return grunt.fail.warn(
+					'\nYou need to have "GNU Gettext" installed and in your PATH for this task to work.' +
+					'More info: http://www.gnu.org/software/gettext\n'
+				);
+			}
 		}
 
 		if ( this.files.length < 1 ) {


### PR DESCRIPTION
I hope my problem is reproducable. The `which()` function from shelljs does not work properly on Windows with nodejs 0.10.34.
The only option is to skip the test and the system will just print its own error message.
